### PR TITLE
Add the ability to skip tests on built wheels in the release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,9 @@ jobs:
         python setup.py bdist_wheel
 
     - name: Test Wheels
-      if: "!startsWith(matrix.os, 'windows')"
+      if: |
+        !startsWith(matrix.os, 'windows')
+        && !contains(github.event.pull_request.labels.*.name, 'skip wheel tests')
       run: |
         pip install --pre edgedb[test] -f "file:///${GITHUB_WORKSPACE}/dist"
         make -C "${GITHUB_WORKSPACE}" testinstalled


### PR DESCRIPTION
Adding the "skip wheel tests" would skip the testing of the built
wheels.  This is sometimes needed for breaking changes, where the
dependencies have not been published yet.