### PR TITLE
Rename transaction methods (#169)

### DIFF
--- a/docs/api/asyncio_con.rst
+++ b/docs/api/asyncio_con.rst
@@ -234,14 +234,15 @@ Connection
             If the results of *query* are desired, :py:meth:`query` or
             :py:meth:`query_one` should be used instead.
 
-    .. py:method:: retry()
+    .. py:method:: retrying_transaction()
 
-        Open a retryable transaction loop.
+        Start a transaction with auto-retry semantics.
 
         This is the preferred method of initiating and running a database
-        transaction in a robust fashion.  The ``retry()`` transaction loop will
-        attempt to re-execute the transaction loop body if a transient error
-        occurs, such as a network error or a transaction serialization error.
+        transaction in a robust fashion.  The ``retrying_transaction()``
+        transaction loop will attempt to re-execute the transaction loop
+        body if a transient error occurs, such as a network error or a
+        transaction serialization error.
 
         Returns an instance of :py:class:`AsyncIORetry`.
 
@@ -251,7 +252,7 @@ Connection
 
         .. code-block:: python
 
-            async for tx in con.retry():
+            async for tx in con.retrying_transaction():
                 async with tx:
                     value = await tx.query_one("SELECT Counter.value")
                     await tx.execute(
@@ -262,24 +263,25 @@ Connection
         Note that we are executing queries on the ``tx`` object rather
         than on the original connection.
 
-    .. py:method:: try_transaction()
+    .. py:method:: raw_transaction()
 
-        Execute a non-retryable transaction.
+        Start a low-level transaction.
 
-        Contrary to ``retry()``, ``try_transaction()`` will not attempt
-        to re-run the nested code block in case a retryable error happens.
+        Unlike ``retrying_transaction()``, ``raw_transaction()``
+        will not attempt to re-run the nested code block in case a retryable
+        error happens.
 
-        This is a low-level API and it is advised to use the ``retry()``
-        method instead.
+        This is a low-level API and it is advised to use the
+        ``retrying_transaction()`` method instead.
 
-        A call to ``try_transaction()`` returns
+        A call to ``raw_transaction()`` returns
         :py:class:`AsyncIOTransaction`.
 
         Example:
 
         .. code-block:: python
 
-            async with con.try_transaction() as tx:
+            async with con.raw_transaction() as tx:
                 value = await tx.query_one("SELECT Counter.value")
                 await tx.execute(
                     "UPDATE Counter SET { value := <int64>$value }",
@@ -291,7 +293,8 @@ Connection
 
     .. py:method:: transaction(isolation=None, readonly=None, deferrable=None)
 
-        **Deprecated**. Use :py:meth:`retry` or :py:meth:`try_transaction`.
+        **Deprecated**. Use :py:meth:`retrying_transaction` or
+        :py:meth:`raw_transaction`.
 
         Create a :py:class:`AsyncIOTransaction` object.
 
@@ -364,12 +367,13 @@ Connection Pools
     APIs directly, without manually acquiring and releasing connections
     from the pool:
 
-    * :py:meth:`AsyncIOPool.retry()`
     * :py:meth:`AsyncIOPool.query()`
     * :py:meth:`AsyncIOPool.query_one()`
     * :py:meth:`AsyncIOPool.query_json()`
     * :py:meth:`AsyncIOPool.query_one_json()`
     * :py:meth:`AsyncIOPool.execute()`
+    * :py:meth:`AsyncIOPool.retrying_transaction()`
+    * :py:meth:`AsyncIOPool.raw_transaction()`
 
     .. code-block:: python
 
@@ -381,7 +385,7 @@ Connection Pools
     .. code-block:: python
 
         async with edgedb.create_async_pool(user='edgedb') as pool:
-            async for tx in pool.retry():
+            async for tx in pool.retrying_transaction():
                 async with tx:
                     await tx.query('SELECT {1, 2, 3}')
 
@@ -537,14 +541,15 @@ Connection Pools
         See :py:meth:`AsyncIOConnection.execute()
         <edgedb.AsyncIOConnection.execute>` for details.
 
-    .. py:method:: retry()
+    .. py:method:: retrying_transaction()
 
         Open a retryable transaction loop.
 
         This is the preferred method of initiating and running a database
-        transaction in a robust fashion.  The ``retry()`` transaction loop will
-        attempt to re-execute the transaction loop body if a transient error
-        occurs, such as a network error or a transaction serialization error.
+        transaction in a robust fashion.  The ``retrying_transaction()``
+        transaction loop will attempt to re-execute the transaction loop body
+        if a transient error occurs, such as a network error or a transaction
+        serialization error.
 
         Returns an instance of :py:class:`AsyncIORetry`.
 
@@ -554,7 +559,7 @@ Connection Pools
 
         .. code-block:: python
 
-            async for tx in pool.retry():
+            async for tx in pool.retrying_transaction():
                 async with tx:
                     value = await tx.query_one("SELECT Counter.value")
                     await tx.execute(
@@ -565,24 +570,25 @@ Connection Pools
         Note that we are executing queries on the ``tx`` object rather
         than on the original pool.
 
-    .. py:method:: try_transaction()
+    .. py:method:: raw_transaction()
 
         Execute a non-retryable transaction.
 
-        Contrary to ``retry()``, ``try_transaction()`` will not attempt
-        to re-run the nested code block in case a retryable error happens.
+        Contrary to ``retrying_transaction()``, ``raw_transaction()``
+        will not attempt to re-run the nested code block in case a retryable
+        error happens.
 
-        This is a low-level API and it is advised to use the ``retry()``
-        method instead.
+        This is a low-level API and it is advised to use the
+        ``retrying_transaction()`` method instead.
 
-        A call to ``try_transaction()`` returns
+        A call to ``raw_transaction()`` returns
         :py:class:`AsyncIOTransaction`.
 
         Example:
 
         .. code-block:: python
 
-            async with pool.try_transaction() as tx:
+            async with pool.raw_transaction() as tx:
                 value = await tx.query_one("SELECT Counter.value")
                 await tx.execute(
                     "UPDATE Counter SET { value := <int64>$value",
@@ -599,11 +605,11 @@ Transactions
 ============
 
 The most robust way to execute transactional code is to use
-the ``retry()`` loop API:
+the ``retrying_transaction()`` loop API:
 
 .. code-block:: python
 
-    async for tx in pool.retry():
+    async for tx in pool.retrying_transaction():
         async with tx:
             await tx.execute("INSERT User { name := 'Don' }")
 
@@ -611,13 +617,15 @@ Note that we execute queries on the ``tx`` object in the above
 example, rather than on the original connection pool ``pool``
 object.
 
-The ``retry()`` API guarantees that:
+The ``retrying_transaction()`` API guarantees that:
 
 1. Transactions are executed atomically;
 2. If a transaction is failed for any of the number of transient errors (i.e.
-   a network failure or a concurrent update error), the transaction would be retried;
-3. If any other, non-retryable exception occurs, the transaction is rolled back,
-   and the exception is propagated, immediately aborting the ``retry()`` block.
+   a network failure or a concurrent update error), the transaction would
+   be retried;
+3. If any other, non-retryable exception occurs, the transaction is rolled
+   back, and the exception is propagated, immediately aborting the
+   ``retrying_transaction()`` block.
 
 The key implication of retrying transactions is that the entire
 nested code block can be re-run, including any non-querying
@@ -625,7 +633,7 @@ Python code. Here is an example:
 
 .. code-block:: python
 
-    async for tx in pool.retry():
+    async for tx in pool.retrying_transaction():
         async with tx:
             user = await tx.fetch_one(
                 "SELECT User { email } FILTER .login = <str>$login",
@@ -658,10 +666,10 @@ negatively impact the performance of the DB server.
 See also:
 
 * RFC1004_
-* :py:meth:`AsyncIOPool.retry()`
-* :py:meth:`AsyncIOPool.try_transaction()`
-* :py:meth:`AsyncIOConnection.retry()`
-* :py:meth:`AsyncIOConnection.try_transaction()`
+* :py:meth:`AsyncIOPool.retrying_transaction()`
+* :py:meth:`AsyncIOPool.raw_transaction()`
+* :py:meth:`AsyncIOConnection.retrying_transaction()`
+* :py:meth:`AsyncIOConnection.raw_transaction()`
 
 
 .. py:class:: AsyncIOTransaction
@@ -669,7 +677,7 @@ See also:
     Represents a transaction or a savepoint block.
 
     Instances of this type are created by calling the
-    :py:meth:`AsyncIOConnection.try_transaction()` method.
+    :py:meth:`AsyncIOConnection.raw_transaction()` method.
 
 
     .. py:coroutinemethod:: start()
@@ -741,7 +749,8 @@ See also:
     Represents a wrapper that yields :py:class:`AsyncIOTransaction`
     object when iterating.
 
-    See :py:meth:`AsyncIOConnection.retry()` method for an example.
+    See :py:meth:`AsyncIOConnection.retrying_transaction()`
+    method for an example.
 
     .. py:coroutinemethod:: __anext__()
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -200,15 +200,15 @@ Transactions
 The most robust way to create a
 :ref:`transaction <edgedb-python-asyncio-api-transaction>` is ``retry`` method:
 
-* :py:meth:`AsyncIOPool.retry() <edgedb.AsyncIOPool.retry>`
-* :py:meth:`BlockingIOConnection.retry() <edgedb.BlockingIOConnection.retry>`
-* :py:meth:`AsyncIOConnection.retry() <edgedb.AsyncIOConnection.retry>`
+* :py:meth:`AsyncIOPool.retrying_transaction() <edgedb.AsyncIOPool.retrying_transaction>`
+* :py:meth:`BlockingIOConnection.retrying_transaction() <edgedb.BlockingIOConnection.retrying_transaction>`
+* :py:meth:`AsyncIOConnection.retrying_transaction() <edgedb.AsyncIOConnection.retrying_transaction>`
 
 Example:
 
 .. code-block:: python
 
-    for tx in connection.retry():
+    for tx in connection.retrying_transaction():
         with tx:
             tx.execute("INSERT User {name := 'Don'}")
 
@@ -216,7 +216,7 @@ or, if using the async API on connection pool:
 
 .. code-block:: python
 
-    async for tx in connection.retry():
+    async for tx in connection.retrying_transaction():
         async with tx:
             await tx.execute("INSERT User {name := 'Don'}")
 

--- a/edgedb/_testbase.py
+++ b/edgedb/_testbase.py
@@ -289,7 +289,7 @@ class DatabaseTestCase(ClusterTestCase, ConnectedTestCaseMixin):
                     'CONFIGURE SESSION SET __internal_testmode := true;'))
 
         if self.ISOLATED_METHODS:
-            self.xact = self.con.try_transaction()
+            self.xact = self.con.raw_transaction()
             self.loop.run_until_complete(self.xact.start())
 
         if self.SETUP_METHOD:
@@ -346,7 +346,7 @@ class DatabaseTestCase(ClusterTestCase, ConnectedTestCaseMixin):
             if script:
                 # The setup is expected to contain a CREATE MIGRATION,
                 # which needs to be wrapped in a transaction.
-                tx = cls.con.try_transaction()
+                tx = cls.con.raw_transaction()
                 cls.loop.run_until_complete(tx.start())
                 cls.loop.run_until_complete(tx.execute(script))
                 cls.loop.run_until_complete(tx.commit())

--- a/edgedb/asyncio_con.py
+++ b/edgedb/asyncio_con.py
@@ -367,16 +367,16 @@ class AsyncIOConnection(base_con.BaseConnection, abstract.AsyncIOExecutor):
     ) -> legacy_transaction.AsyncIOTransaction:
         warnings.warn(
             'The "transaction()" method is deprecated and is scheduled to be '
-            'removed. Use the "retry()" or "try_transaction()" method '
-            'instead.',
+            'removed. Use the "retrying_transaction()" or "raw_transaction()" '
+            'method instead.',
             DeprecationWarning, 2)
         return legacy_transaction.AsyncIOTransaction(
             self, isolation, readonly, deferrable)
 
-    def retry(self) -> _retry.AsyncIORetry:
+    def retrying_transaction(self) -> _retry.AsyncIORetry:
         return _retry.AsyncIORetry(self)
 
-    def try_transaction(self) -> _transaction.AsyncIOTransaction:
+    def raw_transaction(self) -> _transaction.AsyncIOTransaction:
         return _transaction.AsyncIOTransaction(self)
 
     async def aclose(self) -> None:

--- a/edgedb/asyncio_pool.py
+++ b/edgedb/asyncio_pool.py
@@ -661,10 +661,10 @@ class AsyncIOPool(abstract.AsyncIOExecutor):
     async def __aexit__(self, *exc):
         await self.aclose()
 
-    def try_transaction(self) -> _transaction.AsyncIOTransaction:
+    def raw_transaction(self) -> _transaction.AsyncIOTransaction:
         return _transaction.AsyncIOTransaction(self)
 
-    def retry(self) -> _retry.AsyncIORetry:
+    def retrying_transaction(self) -> _retry.AsyncIORetry:
         return _retry.AsyncIORetry(self)
 
 

--- a/edgedb/blocking_con.py
+++ b/edgedb/blocking_con.py
@@ -329,16 +329,16 @@ class BlockingIOConnection(base_con.BaseConnection, abstract.Executor):
                     deferrable: bool = None) -> legacy_transaction.Transaction:
         warnings.warn(
             'The "transaction()" method is deprecated and is scheduled to be '
-            'removed. Use the "retry()" or "try_transaction()" method '
-            'instead.',
+            'removed. Use the "retrying_transaction()" or "raw_transaction()" '
+            'method instead.',
             DeprecationWarning, 2)
         return legacy_transaction.Transaction(
             self, isolation, readonly, deferrable)
 
-    def try_transaction(self) -> _transaction.Transaction:
+    def raw_transaction(self) -> _transaction.Transaction:
         return _transaction.Transaction(self)
 
-    def retry(self) -> _retry.Retry:
+    def retrying_transaction(self) -> _retry.Retry:
         return _retry.Retry(self)
 
     def close(self) -> None:

--- a/edgedb/legacy_transaction.py
+++ b/edgedb/legacy_transaction.py
@@ -19,7 +19,7 @@
 This module provides support for legacy `connection.transaction()` method.
 
 This API is deprecated and will eventually be removed.
-Use `retry()` or `try_transaction()` instead.
+Use `retrying_transaction()` or `raw_transaction()` instead.
 """
 
 import enum

--- a/tests/test_async_fetch.py
+++ b/tests/test_async_fetch.py
@@ -749,7 +749,7 @@ class TestAsyncFetch(tb.AsyncQueryTestCase):
 
         con2 = await self.connect(database=self.con.dbname)
 
-        async with self.con.try_transaction() as tx:
+        async with self.con.raw_transaction() as tx:
             await tx.query_one(
                 'select sys::_advisory_lock(<int64>$0)',
                 lock_key)
@@ -762,7 +762,7 @@ class TestAsyncFetch(tb.AsyncQueryTestCase):
                             edgedb.ClientConnectionClosedError,
                             ConnectionResetError,
                         )):
-                            async with con2.try_transaction() as tx2:
+                            async with con2.raw_transaction() as tx2:
                                 await tx2.query(
                                     'select sys::_advisory_lock(<int64>$0)',
                                     lock_key,
@@ -805,7 +805,7 @@ class TestAsyncFetch(tb.AsyncQueryTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.InvalidValueError, 'invalid input value for enum'):
-            async with self.con.try_transaction() as tx:
+            async with self.con.raw_transaction() as tx:
                 await tx.query_one('SELECT <MyEnum><str>$0', 'Oups')
 
         self.assertEqual(
@@ -818,7 +818,7 @@ class TestAsyncFetch(tb.AsyncQueryTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.InvalidValueError, 'invalid input value for enum'):
-            async with self.con.try_transaction() as tx:
+            async with self.con.raw_transaction() as tx:
                 await tx.query_one('SELECT <MyEnum>$0', 'Oups')
 
         with self.assertRaisesRegex(

--- a/tests/test_async_retry.py
+++ b/tests/test_async_retry.py
@@ -64,7 +64,7 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
     '''
 
     async def test_async_retry_01(self):
-        async for tx in self.con.retry():
+        async for tx in self.con.retrying_transaction():
             async with tx:
                 await tx.execute('''
                     INSERT test::Counter {
@@ -74,7 +74,7 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
 
     async def test_async_retry_02(self):
         with self.assertRaises(ZeroDivisionError):
-            async for tx in self.con.retry():
+            async for tx in self.con.retrying_transaction():
                 async with tx:
                     await tx.execute('''
                         INSERT test::Counter {
@@ -97,7 +97,7 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
         iterations = 0
 
         async def transaction1(con):
-            async for tx in con.retry():
+            async for tx in con.retrying_transaction():
                 nonlocal iterations
                 iterations += 1
                 async with tx:
@@ -144,11 +144,11 @@ class TestAsyncRetry(tb.AsyncQueryTestCase):
     async def test_async_transaction_interface_errors(self):
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*the transaction is already started'):
-            async for tx in self.con.retry():
+            async for tx in self.con.retrying_transaction():
                 async with tx:
                     await tx.start()
 
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*Use `async with transaction:`'):
-            async for tx in self.con.retry():
+            async for tx in self.con.retrying_transaction():
                 await tx.start()

--- a/tests/test_async_tx.py
+++ b/tests/test_async_tx.py
@@ -38,7 +38,7 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
 
     async def test_async_transaction_regular_01(self):
         self.assertIsNone(self.con._borrowed_for)
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         self.assertIsNone(self.con._borrowed_for)
 
         with self.assertRaises(ZeroDivisionError):
@@ -75,7 +75,7 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
     async def test_async_transaction_interface_errors(self):
         self.assertIsNone(self.con._borrowed_for)
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot start; .* already started'):
             async with tr:
@@ -93,7 +93,7 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
 
         self.assertIsNone(self.con._borrowed_for)
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot manually commit.*async with'):
             async with tr:
@@ -101,7 +101,7 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
 
         self.assertIsNone(self.con._borrowed_for)
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot manually rollback.*async with'):
             async with tr:
@@ -109,38 +109,38 @@ class TestAsyncTx(tb.AsyncQueryTestCase):
 
         self.assertIsNone(self.con._borrowed_for)
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot enter context:.*async with'):
             async with tr:
                 async with tr:
                     pass
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             async with tr:
                 await self.con.query("SELECT 1")
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             async with tr:
                 await self.con.query_one("SELECT 1")
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             async with tr:
                 await self.con.query_json("SELECT 1")
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             async with tr:
                 await self.con.query_one_json("SELECT 1")
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             async with tr:

--- a/tests/test_sync_retry.py
+++ b/tests/test_sync_retry.py
@@ -61,7 +61,7 @@ class TestSyncRetry(tb.SyncQueryTestCase):
     '''
 
     def test_sync_retry_01(self):
-        for tx in self.con.retry():
+        for tx in self.con.retrying_transaction():
             with tx:
                 tx.execute('''
                     INSERT test::Counter {
@@ -71,7 +71,7 @@ class TestSyncRetry(tb.SyncQueryTestCase):
 
     def test_async_retry_02(self):
         with self.assertRaises(ZeroDivisionError):
-            for tx in self.con.retry():
+            for tx in self.con.retrying_transaction():
                 with tx:
                     tx.execute('''
                         INSERT test::Counter {
@@ -97,7 +97,7 @@ class TestSyncRetry(tb.SyncQueryTestCase):
         iterations = 0
 
         def transaction1(con):
-            for tx in con.retry():
+            for tx in con.retrying_transaction():
                 nonlocal iterations
                 iterations += 1
                 with tx:
@@ -140,11 +140,11 @@ class TestSyncRetry(tb.SyncQueryTestCase):
     def test_sync_transaction_interface_errors(self):
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*the transaction is already started'):
-            for tx in self.con.retry():
+            for tx in self.con.retrying_transaction():
                 with tx:
                     tx.start()
 
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*Use `with transaction:`'):
-            for tx in self.con.retry():
+            for tx in self.con.retrying_transaction():
                 tx.start()

--- a/tests/test_sync_tx.py
+++ b/tests/test_sync_tx.py
@@ -38,7 +38,7 @@ class TestSyncTx(tb.SyncQueryTestCase):
 
     def test_sync_transaction_regular_01(self):
         self.assertIsNone(self.con._borrowed_for)
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         self.assertIsNone(self.con._borrowed_for)
 
         with self.assertRaises(ZeroDivisionError):
@@ -65,7 +65,7 @@ class TestSyncTx(tb.SyncQueryTestCase):
     def test_sync_transaction_interface_errors(self):
         self.assertIsNone(self.con._top_xact)
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot start; .* already started'):
             with tr:
@@ -83,7 +83,7 @@ class TestSyncTx(tb.SyncQueryTestCase):
 
         self.assertIsNone(self.con._top_xact)
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot manually commit.*with'):
             with tr:
@@ -91,7 +91,7 @@ class TestSyncTx(tb.SyncQueryTestCase):
 
         self.assertIsNone(self.con._top_xact)
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot manually rollback.*with'):
             with tr:
@@ -99,38 +99,38 @@ class TestSyncTx(tb.SyncQueryTestCase):
 
         self.assertIsNone(self.con._top_xact)
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'cannot enter context:.*with'):
             with tr:
                 with tr:
                     pass
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             with tr:
                 self.con.query("SELECT 1")
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             with tr:
                 self.con.query_one("SELECT 1")
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             with tr:
                 self.con.query_json("SELECT 1")
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             with tr:
                 self.con.query_one_json("SELECT 1")
 
-        tr = self.con.try_transaction()
+        tr = self.con.raw_transaction()
         with self.assertRaisesRegex(edgedb.InterfaceError,
                                     r'.*is borrowed.*'):
             with tr:


### PR DESCRIPTION
* Rename transaction methods

* try_transaction() -> raw_transaction()
* retry() -> retry_transaction()