### PR TITLE
Add certifi on win32

### DIFF
--- a/edgedb/con_utils.py
+++ b/edgedb/con_utils.py
@@ -405,6 +405,9 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                 tls_verify_hostname = False
         else:
             ssl_ctx.load_default_certs(ssl.Purpose.SERVER_AUTH)
+            if platform.IS_WINDOWS:
+                import certifi
+                ssl_ctx.load_verify_locations(cafile=certifi.where())
             if tls_verify_hostname is None:
                 tls_verify_hostname = True
         ssl_ctx.check_hostname = tls_verify_hostname

--- a/setup.py
+++ b/setup.py
@@ -341,6 +341,7 @@ setuptools.setup(
     test_suite='tests.suite',
     install_requires=[
         'typing-extensions>=3.10.0',
+        'certifi>=2021.5.30; platform_system == "Windows"',
     ],
     extras_require=EXTRA_DEPENDENCIES,
     setup_requires=setup_requires,


### PR DESCRIPTION
On Windows, we don't have access to all root CA certs due to bpo-20916.
This PR adds the Mozilla collection of root CA certs on Windows.